### PR TITLE
refactor: use server route prerendering

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,10 +38,7 @@
             "styles": ["src/styles.scss"],
             "scripts": [],
             "server": "src/main.server.ts",
-            "prerender": {
-              "discoverRoutes": false,
-              "routesFile": "prerender-routes.txt"
-            }
+            "outputMode": "static"
           },
           "configurations": {
             "production": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component, signal, VERSION } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { ICON_COMPONENTS } from './shared/icons';
 import { NAV_LIST_DIRECTIVES } from './shared/nav-list/nav-list';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterModule, NAV_LIST_DIRECTIVES, ICON_COMPONENTS],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, NAV_LIST_DIRECTIVES, ICON_COMPONENTS],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -1,43 +1,10 @@
-import { provideServerRendering } from '@angular/ssr';
-import { BEFORE_APP_SERIALIZED } from '@angular/platform-server';
-import { ApplicationConfig, NgZone, inject, mergeApplicationConfig } from '@angular/core';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { setTimeout } from 'node:timers/promises';
-import { firstValueFrom } from 'rxjs';
+import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { appConfig } from './app.config';
-import { markdownPages } from './app.routes';
-import { provideContentCache } from './shared/content-resolver';
-
-function createContentCache() {
-  const cache: Record<string, string> = {};
-  for (const page of markdownPages) {
-    const file = readFileSync(resolve('src', page.src), 'utf-8');
-    cache[page.src] = file;
-  }
-  return cache;
-}
+import { routes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
-  providers: [
-    provideServerRendering(),
-    provideContentCache(createContentCache()),
-    {
-      provide: BEFORE_APP_SERIALIZED,
-      multi: true,
-      useFactory: () => {
-        const ngZone = inject(NgZone);
-        return async () => {
-          // wait for markdown-outlet rendering
-          await setTimeout(1000);
-          if (ngZone.isStable) {
-            return;
-          }
-          await firstValueFrom(ngZone.onStable);
-        };
-      },
-    },
-  ],
+  providers: [provideServerRendering(withRoutes(routes))],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -1,0 +1,5 @@
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const routes: ServerRoute[] = [
+  { path: '**', renderMode: RenderMode.Prerender },
+];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,31 +1,6 @@
-import { inject } from '@angular/core';
 import { Route } from '@angular/router';
 import { HomePageComponent } from './pages/home/home.component';
 import { MarkdownPageComponent } from './pages/markdown/markdown-page.component';
-import { ContentResolver } from './shared/content-resolver';
-
-export const markdownPages = [
-  {
-    path: 'about',
-    src: 'content/about.md',
-    title: 'About',
-  },
-  {
-    path: 'policy',
-    src: 'content/policy.md',
-    title: 'コミュニティポリシー',
-  },
-  {
-    path: 'local',
-    src: 'content/local-communities.md',
-    title: 'ローカルコミュニティ',
-  },
-  {
-    path: 'learn',
-    src: 'content/learn-angular.md',
-    title: 'Angularを学ぶ',
-  },
-] as const;
 
 export const routes: Route[] = [
   {
@@ -33,16 +8,30 @@ export const routes: Route[] = [
     pathMatch: 'full',
     component: HomePageComponent,
   },
-  ...markdownPages.map((page) => ({
-    path: page.path,
+  {
+    path: 'about',
     component: MarkdownPageComponent,
-    resolve: {
-      content: () => {
-        const contentResolver = inject(ContentResolver);
-        return contentResolver.get(page.src);
-      },
-    },
-  })),
+    data: { content: 'content/about.md' },
+    title: 'About',
+  },
+  {
+    path: 'policy',
+    component: MarkdownPageComponent,
+    data: { content: 'content/policy.md' },
+    title: 'コミュニティポリシー',
+  },
+  {
+    path: 'local',
+    component: MarkdownPageComponent,
+    data: { content: 'content/local-communities.md' },
+    title: 'ローカルコミュニティ',
+  },
+  {
+    path: 'learn',
+    component: MarkdownPageComponent,
+    data: { content: 'content/learn-angular.md' },
+    title: 'Angularを学ぶ',
+  },
   {
     path: '**',
     redirectTo: '/',

--- a/src/app/pages/markdown/markdown-page.component.ts
+++ b/src/app/pages/markdown/markdown-page.component.ts
@@ -1,20 +1,33 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, resource } from '@angular/core';
 import { MarkdownOutletComponent } from '../../shared/markdown-outlet/markdown-outlet.component';
+import { ContentResolver } from 'src/app/shared/content-resolver';
 
 @Component({
   imports: [MarkdownOutletComponent],
   template: `
-    @defer (hydrate never) {
-    <app-markdown-outlet class="h-full" [content]="content()" />
+    @if(markdownResource.value(); as markdown) {
+    <app-markdown-outlet class="h-full" [content]="markdown" />
     }
   `,
   styles: `
-      :host {
-        display: block;
-      }
-    `,
+    :host {
+      display: block;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MarkdownPageComponent {
+  readonly #contentResolver = inject(ContentResolver);
+
+  /**
+   * The relative path to the Markdown file to be rendered.
+   */
   readonly content = input.required<string>();
+
+  readonly markdownResource = resource({
+    params: () => this.content() ?? undefined,
+    loader: async ({ params: content }) => {
+      return this.#contentResolver.get(content);
+    },
+  });
 }

--- a/src/app/shared/content-resolver.ts
+++ b/src/app/shared/content-resolver.ts
@@ -1,22 +1,11 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Injectable, InjectionToken, inject, makeEnvironmentProviders } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-
-const CONTENT_CACHE = new InjectionToken<Record<string, string>>('CONTENT_CACHE');
-
-export function provideContentCache(value: Record<string, string>) {
-  return makeEnvironmentProviders([
-    {
-      provide: CONTENT_CACHE,
-      useValue: value,
-    },
-  ]);
-}
 
 @Injectable({ providedIn: 'root' })
 export class ContentResolver {
   readonly #httpClient = inject(HttpClient);
-  readonly #contentCache = inject(CONTENT_CACHE, { optional: true });
+  readonly #contentCache: Record<string, string> = {};
 
   async get(url: string) {
     if (this.#contentCache && this.#contentCache[url]) {


### PR DESCRIPTION
This pull request refactors the Angular application to simplify server-side rendering (SSR) and content handling, while also improving maintainability and reducing complexity. Key changes include replacing custom prerendering logic with Angular's built-in SSR features, updating the routing structure, and refactoring the content resolver to remove unnecessary dependencies.

### Server-side rendering and prerendering updates:
* Replaced the custom prerender configuration in `angular.json` with `outputMode: static` for simpler static site generation.
* Updated `src/app/app.config.server.ts` to use `provideServerRendering` with `withRoutes` for configuring SSR routes, replacing the custom content cache and serialization logic.
* Added a new `src/app/app.routes.server.ts` file to define server-specific routes with prerendering enabled using `RenderMode.Prerender`.

### Routing and content handling refactor:
* Consolidated `src/app/app.routes.ts` by replacing the previous `markdownPages` array and its resolver logic with a unified `routes` array that includes `data` attributes for content paths.
* Refactored `MarkdownPageComponent` to use Angular's `resource` for content loading, eliminating the need for the `@defer` directive and simplifying the template. [[1]](diffhunk://#diff-bf88daaf091d2f9e0ad9df2d4ca8940b9d381c1293244f04390e3710f7ce38beL1-R9) [[2]](diffhunk://#diff-bf88daaf091d2f9e0ad9df2d4ca8940b9d381c1293244f04390e3710f7ce38beR20-R32)

### Content resolver simplification:
* Removed the `CONTENT_CACHE` injection token and associated providers from `src/app/shared/content-resolver.ts`, replacing it with a simpler in-memory cache directly within the `ContentResolver` class.