### PR TITLE
feat(ui): visual refresh with brand tokens and editorial typography

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,9 +50,9 @@ export default tseslint.config(
     },
   },
   {
-    // Everything in this config object targets our HTML files (both external template files,
+    // Everything in this config object targets our HTML files under src/ (external template files,
     // AND inline templates thanks to the processor set in the TypeScript config above)
-    files: ['**/*.html'],
+    files: ['src/**/*.html'],
     extends: [
       // Apply the recommended Angular template rules
       ...angular.configs.templateRecommended,

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,16 +1,16 @@
 <div class="h-screen flex flex-col" [class.overflow-hidden]="isMenuOpen()">
   <header>
-    <div class="flex flex-row items-center justify-between h-14 lg:h-16 px-4 text-gray-500 md:hidden">
-      <span class="text-xl">Japan Angular User Group</span>
-
+    <div class="flex flex-row items-center gap-3 h-14 px-4 text-ink border-b border-line lg:hidden">
       <button
         aria-label="open menu"
         aria-haspopup="menu"
-        class="flex items-center justify-center w-10 h-10 rounded focus:ring"
+        class="flex items-center justify-center w-10 h-10 rounded focus-visible:ring-2 focus-visible:ring-brand-1"
         (click)="toggleMenu()"
       >
         <app-icon-menu></app-icon-menu>
       </button>
+      <img src="/assets/image/logo.svg" class="w-6 h-6" width="24" height="24" alt="" />
+      <span class="font-display font-bold text-[14px]">Japan Angular User Group</span>
     </div>
   </header>
 
@@ -22,13 +22,14 @@
       [class.hidden]="!isMenuOpen()"
       (click)="closeMenu()"
     ></div>
-    <!-- sidenav -->
+    <!-- sidenav / drawer -->
     <div
-      class="bg-white shadow z-10 w-64 fixed top-14 md:top-0 md:h-full left-0 h-[calc(100%-3.5rem)] transform md:translate-x-0 transition duration-200 ease-in-out"
+      class="bg-white shadow z-10 w-64 fixed top-14 lg:top-0 lg:h-full left-0 h-[calc(100%-3.5rem)] transform lg:translate-x-0 transition duration-200 ease-in-out"
       [class.-translate-x-full]="!isMenuOpen()"
     >
-      <div class="flex justify-center pt-2">
-        <img src="/assets/image/logo.svg" class="w-12" width="96" height="96" alt="ng-japan" />
+      <div class="flex flex-row items-center pt-3 lg:pt-6 pb-4 gap-3 px-4">
+        <img src="/assets/image/logo.svg" class="w-9 h-9 shrink-0" width="36" height="36" alt="ng-japan" />
+        <div class="font-display font-bold text-[13px] text-ink leading-tight">Japan Angular User Group</div>
       </div>
       <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events, @angular-eslint/template/interactive-supports-focus -->
       <nav appNavList (click)="closeMenu()">
@@ -56,16 +57,23 @@
     </div>
 
     <!-- content -->
-    <div class="flex-1 h-full flex flex-col ml-0 md:ml-64">
+    <div class="flex-1 h-full flex flex-col ml-0 lg:ml-64">
       <main class="flex-1 px-6 py-4">
         <router-outlet></router-outlet>
       </main>
 
-      <footer class="text-center p-2">
+      <footer class="text-center p-2 text-muted">
         <div>&copy; Japan Angular User Group</div>
         <div class="flex flex-row gap-x-2 justify-center items-center text-sm">
           <span>Built with Angular v{{ ngVersion }}</span>
-          <a href="https://github.com/ng-japan/community.angular.jp" target="_blank" rel="noopener"> GitHub </a>
+          <a
+            href="https://github.com/ng-japan/community.angular.jp"
+            target="_blank"
+            rel="noopener"
+            class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+          >
+            GitHub
+          </a>
         </div>
       </footer>
     </div>

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,9 +1,14 @@
 <div class="h-full flex flex-col gap-6">
-  <div class="flex flex-row items-center gap-4">
-    <img src="/assets/image/logo.svg" class="w-24 md:w-36" width="96" height="96" alt="ng-japan" />
-
-    <h1 class="text-xl md:text-3xl py-4">日本Angularユーザー会へようこそ!</h1>
-  </div>
+  <section class="hero">
+    <div class="hero-deco" aria-hidden="true">
+      <img src="/assets/image/logo.svg" alt="" />
+    </div>
+    <div class="hero-content">
+      <h1 class="hero-h1 font-display">
+        日本<span class="hero-h1__brand font-display">Angular</span>ユーザー会へようこそ!
+      </h1>
+    </div>
+  </section>
 
   <section>
     <p class="mb-2">
@@ -12,26 +17,51 @@
     </p>
     <p>
       ユーザー会にはどなたでも参加できます。Angularをすでにお使いの方も、これから始めようと思っている方も歓迎します。<br />
-      コミュニティの運営方針については<a [routerLink]="'/policy'">コミュニティポリシー</a>をご確認ください。
+      コミュニティの運営方針については<a
+        [routerLink]="'/policy'"
+        class="text-ink underline decoration-2 underline-offset-[6px] decoration-brand-1"
+        >コミュニティポリシー</a
+      >をご確認ください。
     </p>
   </section>
 
-  <section class="grid grid-flow-row lg:grid-cols-3 gap-4">
+  <section class="grid grid-flow-row lg:grid-cols-2 xl:grid-cols-3 gap-4">
     <app-card class="lg:col-span-2">
       <app-icon-people card-icon></app-icon-people>
       <span card-title>コミュニティに参加する</span>
       <div class="flex flex-col gap-2">
         <p>
-          情報交換やQ&A、お知らせなどに使っているGitHub Discussionsフォーラムはこちら！<br />
-          <a href="https://github.com/ng-japan/community/" target="_blank" rel="noopener"> フォーラムを見る </a>
+          情報交換やQ&Aお知らせなどに使っているGitHub Discussionsフォーラムはこちら！<br />
+          <a
+            href="https://github.com/ng-japan/community/"
+            target="_blank"
+            rel="noopener"
+            class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+          >
+            フォーラムを見る
+          </a>
         </p>
         <p>
           カジュアルな雑談や議論などの交流は Discord へご参加ください！<br />
-          <a href="http://join-discord.angular.jp" target="_blank" rel="noopener"> Discordサーバーに参加 </a>
+          <a
+            href="http://join-discord.angular.jp"
+            target="_blank"
+            rel="noopener"
+            class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+          >
+            Discordサーバーに参加
+          </a>
         </p>
         <p>
           公式Twitterアカウントでは、イベント情報などを不定期に投稿しています。ぜひフォローしてください！<br />
-          <a href="https://twitter.com/ng_japan" target="_blank" rel="noopener"> &#64;ng_japan をフォロー</a>
+          <a
+            href="https://twitter.com/ng_japan"
+            target="_blank"
+            rel="noopener"
+            class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+          >
+            &#64;ng_japan をフォロー
+          </a>
         </p>
       </div>
     </app-card>
@@ -42,7 +72,14 @@
       <p class="mb-4">
         イベントのほとんどはconnpassで公開されます。ぜひグループに参加してイベント情報をGETしてください！
       </p>
-      <a href="https://ngjapan.connpass.com/" target="_blank" rel="noopener"> connpassグループに参加 </a>
+      <a
+        href="https://ngjapan.connpass.com/"
+        target="_blank"
+        rel="noopener"
+        class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+      >
+        connpassグループに参加
+      </a>
     </app-card>
 
     <app-card>
@@ -52,7 +89,12 @@
         YouTubeではオンラインイベント「ng-japan
         OnAir」の放送や、オフラインイベントのライブストリーミングなどもおこなっています。<br />
       </p>
-      <a href="https://www.youtube.com/channel/UCayXpiOPFQh9MWePLoEFLmg" target="_blank" rel="noopener">
+      <a
+        href="https://www.youtube.com/channel/UCayXpiOPFQh9MWePLoEFLmg"
+        target="_blank"
+        rel="noopener"
+        class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+      >
         YouTubeチャンネルをチェック
       </a>
     </app-card>
@@ -61,10 +103,24 @@
       <app-icon-book card-icon></app-icon-book>
       <span card-title>日本語版Angularドキュメント</span>
       <p class="mb-4">
-        <a href="https://angular.jp/" target="_blank" rel="noopener"> angular.jp </a>
+        <a
+          href="https://angular.jp/"
+          target="_blank"
+          rel="noopener"
+          class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+        >
+          angular.jp
+        </a>
         は日本語版のAngular公式ドキュメントです。翻訳に協力してくれるコントリビューターを募集しています！
       </p>
-      <a href="https://github.com/angular/angular-ja" target="_blank" rel="noopener"> 翻訳プロジェクトに参加 </a>
+      <a
+        href="https://github.com/angular/angular-ja"
+        target="_blank"
+        rel="noopener"
+        class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+      >
+        翻訳プロジェクトに参加
+      </a>
     </app-card>
 
     <app-card>
@@ -73,7 +129,12 @@
       <p class="mb-4">
         日本各地のローカルコミュニティがイベントを開催しています。お住まいの街の近くにあるコミュニティを探してみましょう！
       </p>
-      <a [routerLink]="'/local'"> ローカルコミュニティを探す </a>
+      <a
+        [routerLink]="'/local'"
+        class="text-ink underline decoration-2 underline-offset-[4px] decoration-brand-1"
+      >
+        ローカルコミュニティを探す
+      </a>
     </app-card>
   </section>
 </div>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -7,10 +7,86 @@ import { ICON_COMPONENTS } from '../../shared/icons';
   imports: [RouterLink, CardComponent, ICON_COMPONENTS],
   templateUrl: './home.component.html',
   styles: `
-      :host {
-        display: block;
+    :host {
+      display: block;
+    }
+
+    .hero {
+      position: relative;
+      overflow: hidden;
+      margin: -16px -24px 0;
+      padding: 48px 24px;
+    }
+    @media (min-width: 768px) {
+      .hero {
+        /* main's px-6 (24px) at every breakpoint — keep hero confined to it to avoid horizontal overflow.
+           padding-top 64px aligns hero h1 with main content top (markdown h1 / sidenav brand). */
+        margin: -16px -24px 0;
+        padding: 64px 24px;
       }
-    `,
+    }
+
+    .hero-deco {
+      position: absolute;
+      pointer-events: none;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: 580px;
+      height: 580px;
+      opacity: 0.05;
+    }
+    .hero-deco img {
+      width: 100%;
+      height: 100%;
+    }
+    @media (min-width: 768px) {
+      .hero-deco {
+        width: 520px;
+        height: 520px;
+        opacity: 0.06;
+      }
+    }
+    @media (min-width: 1024px) {
+      .hero-deco {
+        left: auto;
+        right: -220px;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 720px;
+        height: 720px;
+        opacity: 0.16;
+      }
+    }
+
+    .hero-content {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .hero-h1 {
+      font-weight: 800;
+      font-size: clamp(34px, 5.5vw, 72px);
+      line-height: 1.15;
+      word-break: auto-phrase;
+      line-break: strict;
+      text-wrap: pretty;
+      max-width: 14em;
+      letter-spacing: -0.025em;
+      margin: 0;
+    }
+
+    .hero-h1__brand {
+      background: linear-gradient(115deg, var(--brand-1), var(--brand-2));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      font-variation-settings: 'wdth' 75;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomePageComponent {}

--- a/src/app/shared/card/card.component.ts
+++ b/src/app/shared/card/card.component.ts
@@ -3,8 +3,10 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 @Component({
   selector: 'app-card',
   template: `
-    <div class="h-full w-full bg-white rounded-md p-4 border border-gray-700 shadow">
-      <div class="flex flex-row items-center justify-start text-lg gap-2 mb-4">
+    <div
+      class="h-full w-full bg-white rounded p-5 md:p-6 border border-line transition-colors hover:border-ink"
+    >
+      <div class="flex flex-row items-center justify-start font-display font-bold text-lg md:text-xl gap-2 mb-4">
         <ng-content select="[card-icon]" />
         <ng-content select="[card-title]" />
       </div>

--- a/src/app/shared/nav-list/nav-list.spec.ts
+++ b/src/app/shared/nav-list/nav-list.spec.ts
@@ -17,7 +17,7 @@ describe('NavListDirective', () => {
 });
 
 describe('NavListItemDirective', () => {
-  it('should render', async () => {
+  it('should render with muted/transparent classes when inactive', async () => {
     const { getByTestId } = await render(`<div appNavListItem data-testid="TEST"></div>`, {
       imports: [NavListItemDirective],
     });
@@ -27,12 +27,15 @@ describe('NavListItemDirective', () => {
       'h-12',
       'px-4',
       'no-underline',
-      'text-black',
-      'hover:bg-gray-100',
+      'font-display',
+      'transition-colors',
+      'border-l-2',
+      'text-muted',
+      'border-transparent',
     );
   });
 
-  it('should change background color if active', async () => {
+  it('should resolve to ink color, brand-1 border and aria-current when route is active', async () => {
     const { getByTestId, detectChanges } = await render(
       `<div appNavListItem data-testid="TEST" routerLink="/active" routerLinkActive></div>`,
       {
@@ -46,6 +49,10 @@ describe('NavListItemDirective', () => {
 
     detectChanges();
 
-    expect(getByTestId('TEST')).toHaveClassName('bg-gray-100');
+    const el = getByTestId('TEST');
+    expect(el).toHaveClassName('text-ink', 'font-semibold', 'border-brand-1');
+    expect(el).not.toHaveClassName('text-muted');
+    expect(el).not.toHaveClassName('border-transparent');
+    expect(el).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/src/app/shared/nav-list/nav-list.ts
+++ b/src/app/shared/nav-list/nav-list.ts
@@ -4,8 +4,13 @@ import { RouterLinkActive } from '@angular/router';
 @Directive({
   selector: '[appNavListItem]',
   host: {
-    class: 'flex items-center h-12 px-4 no-underline text-black hover:bg-gray-100',
-    '[class.bg-gray-100]': 'active',
+    class: 'flex items-center h-12 px-4 no-underline hover:text-ink font-display transition-colors border-l-2',
+    '[class.text-muted]': '!active',
+    '[class.border-transparent]': '!active',
+    '[class.text-ink]': 'active',
+    '[class.font-semibold]': 'active',
+    '[class.border-brand-1]': 'active',
+    '[attr.aria-current]': 'active ? "page" : null',
   },
 })
 export class NavListItemDirective {

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg" href="assets/favicon.svg" />
 
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;600;700;800&family=Noto+Sans+JP:wght@400;700&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;600;700;800&family=Noto+Sans+JP:wght@400;700&display=swap"
+      />
+    </noscript>
+
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLEYS8P7XV"></script>
     <script>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,45 +1,97 @@
+:root {
+  --bg: #fdfdfb;
+  --ink: #131311;
+  --muted: #6e6a5e;
+  --line: #ddd8c8;
+  --brand-1: #cd3679;
+  --brand-2: #801fdf;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  a {
-    @apply text-blue-600 underline;
+  body {
+    @apply bg-bg text-ink font-sans;
+    font-feature-settings: 'palt';
+    -webkit-font-smoothing: antialiased;
   }
 }
 
 .markdown-outlet {
   .content-root {
     @apply flex flex-col;
+    max-width: 38em;
+    line-height: 1.95;
 
     > h1 {
-      @apply font-semibold text-3xl py-4;
+      @apply font-display font-bold text-ink;
+      font-size: clamp(28px, 4vw, 40px);
+      line-height: 1.2;
+      letter-spacing: -0.02em;
+      /* align with home hero top spacing: mobile 48px (main py-4 + 32px), md+ 64px (16px + 48px) */
+      margin: 2rem 0;
+    }
+
+    @media (min-width: 768px) {
+      > h1 {
+        margin-top: 3rem;
+      }
     }
     > h2 {
-      @apply text-xl py-4 mt-4 border-t-2;
+      @apply font-display font-semibold text-ink border-line;
+      font-size: clamp(20px, 2.4vw, 26px);
+      line-height: 1.3;
+      margin: 3.5rem 0 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--line);
     }
     > h3 {
-      @apply font-semibold text-lg py-2 mt-2;
+      @apply font-display font-semibold text-ink;
+      font-size: clamp(16px, 1.8vw, 18px);
+      line-height: 1.4;
+      margin: 2rem 0 0.5rem;
     }
     > p {
-      @apply mt-2;
+      margin: 0 0 1.25rem;
+      line-break: strict;
+      text-wrap: pretty;
     }
     ul {
-      @apply list-inside mt-2;
+      @apply list-inside;
       list-style-type: disc;
+      margin: 0 0 1.25rem;
 
       li {
         @apply py-1;
       }
 
-      // Nested list
       ul {
         @apply pl-4 md:pl-8;
         list-style-type: circle;
+        margin-top: 0.25rem;
       }
     }
     > blockquote {
-      @apply border-l-4 border-gray-300 text-gray-700 pl-4 py-2 mt-3 italic;
+      border-left: 4px solid var(--brand-1);
+      background: rgba(205, 54, 121, 0.04);
+      color: var(--ink);
+      padding: 1rem 1.25rem;
+      margin: 1.5rem 0;
+      font-style: normal;
+    }
+    a {
+      color: var(--ink);
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+      text-underline-offset: 4px;
+      text-decoration-color: var(--brand-1);
+    }
+    img {
+      margin: 1rem 0;
+      max-width: 100%;
+      height: auto;
     }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,22 @@ module.exports = {
   prefix: '',
   mode: 'jit',
   content: ['./src/**/*.{html,ts,css,scss,sass,less,styl,md}'],
-  darkMode: 'media', // or 'media' or 'class'
+  darkMode: 'media',
   theme: {
     extend: {
       colors: {
-        primary: '#3f51b5',
+        bg: 'var(--bg)',
+        ink: 'var(--ink)',
+        muted: 'var(--muted)',
+        line: 'var(--line)',
+        brand: {
+          1: 'var(--brand-1)',
+          2: 'var(--brand-2)',
+        },
+      },
+      fontFamily: {
+        sans: ['"Noto Sans JP"', 'sans-serif'],
+        display: ['"Bricolage Grotesque"', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary

community.angular.jp の UI を visual refresh します。**既存 DOM 構造とコンポーネントは保持**、変更は color tokens / typography / hero 装飾 / sidenav active 表現 / markdown prose に限定しています。

UX バグ修正の例外として 2 件だけ構造に手を入れています:
- mobile-header の hamburger ボタンを **左** に移動 (左 drawer のアフォーダンスと整合させるため)
- card grid `lg:grid-cols-3` → **`lg:grid-cols-2 xl:grid-cols-3`** (1024 viewport では sidenav + main 残幅で 3 列だと「日本語版Angularドキュメント」の card title が char-break で崩壊するため)

## Visual changes

**Color tokens** (`src/styles.scss` `:root` + `tailwind.config.js` `theme.extend.colors`):

| token | value | role |
|---|---|---|
| `--bg` | `#fdfdfb` | paper background |
| `--ink` | `#131311` | text primary |
| `--muted` | `#6e6a5e` | text secondary |
| `--line` | `#ddd8c8` | border / divider |
| `--brand-1` | `#cd3679` | brand pink |
| `--brand-2` | `#801fdf` | brand purple |

legacy `colors.primary: '#3f51b5'` は削除しました。

**Typography**: Bricolage Grotesque (display = 見出し / nav / brand) + Noto Sans JP (本文)。Google Fonts は `media="print" onload="this.media='all'"` + `<noscript>` fallback で非同期ロード、SSR の first paint を third-party domain でブロックしないようにしてあります。weights は実際に参照される `400 / 600 / 700 / 800` (Bricolage) と `400 / 700` (Noto JP) のみ。

**Hero** (`home.component.ts` inline styles + `home.component.html`):
- `<section class="hero">` に cropped logo 装飾を背景に (mobile 580px @.05 / tablet 520px @.06 / desktop 720px @.16 で responsive 切替、右配置は ≥1024)
- h1 = `clamp(34px, 5.5vw, 72px)` + `word-break: auto-phrase` + `line-break: strict` + `text-wrap: pretty` + `max-width: 14em` で全 viewport 2 行 phrase 境界 wrap、`<br>` は使わない方針

**Sidenav active state** (`shared/nav-list/nav-list.ts`):
- 既存の `bg-gray-100` を撤去、**brand-1 左 2px 縦バー + `text-ink` + `font-semibold`** に
- host bindings で `text-muted ⇄ text-ink` と `border-transparent ⇄ border-brand-1` を `[class.*]="!active"` / `[class.*]="active"` の mutually-exclusive 切替に。これで Tailwind の cascade order に結果が依存しない (== 同じ要素に矛盾する色 utility が同時付与されない)
- `aria-current="page"` も active 時に付与

**Sidenav brand block** (`app.component.html`、既存実装は logo のみだった箇所): ロゴ 36px + 「Japan Angular User Group」を横並びで追加

**Card** (`shared/card/card.component.ts`): `border-gray-700` + `shadow` → `border-line` + `hover:border-ink` + `rounded` + Bricolage タイトル

**Markdown prose** (`styles.scss > .markdown-outlet .content-root`):
- Bricolage 見出し (h1 / h2 / h3) + h2 上に `border-line` 1px
- brand-1 underline link
- brand-1 blockquote 縦バー + 薄ピンク背景

**Sidenav 出現 breakpoint**: `md:` → `lg:` (≥ 1024)。1024 未満は mobile drawer のみ表示。

## Test plan

- [x] `CI=true pnpm test --no-watch` → 9/9 PASS (`NavListItemDirective` active state を class 存在 + 非存在の双方向で assert、cascade conflict regression を未然に防ぐ)
- [x] `pnpm lint` → 0 errors
- [x] `pnpm build` → success
- [x] dev server で 360 / 600 / 820 / 1024 / 1440 × `/` `/about` `/policy` + mobile drawer 開閉、すべて崩れなし確認 (各 viewport で sidenav active 縦バーが visible、hero h1 が phrase 境界 wrap、card title が 1 行収容、水平 overflow 無し)
- [ ] Reviewer による visual + a11y 確認 (focus-visible ring brand-1 / `aria-current` / SSR safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)